### PR TITLE
deps doesn't observe ignore/external/exclude

### DIFF
--- a/index.js
+++ b/index.js
@@ -414,6 +414,10 @@ Browserify.prototype.deps = function (opts) {
     
     opts.modules = self._builtins;
     opts.extensions = self._extensions;
+
+    opts.filter = function(id) {
+      return !self._exclude[id] && !self._external[id] && !self._ignore[id];
+    };
     
     if (!opts.basedir) opts.basedir = self._basedir;
     var d = mdeps(self.files, opts);

--- a/test/deps.js
+++ b/test/deps.js
@@ -1,0 +1,27 @@
+var browserify = require('../');
+var vm = require('vm');
+var test = require('tap').test;
+var through = require('through');
+
+test('deps', function (t) {
+    t.plan(1);
+    var b = browserify(__dirname + '/ignore/by-id.js');
+    b.exclude('events');
+    b.exclude('beep');
+    b.exclude('bad id');
+    b.exclude('./skip.js');
+    var deps = [];
+    b.deps()
+      .pipe(through(function (row) {
+        deps.push({ id: row.id, deps: row.deps });
+      }))
+      .on('end', function () {
+          t.deepEqual(deps.sort(cmp), [
+              { id: __dirname + '/ignore/by-id.js', deps: {} }
+          ]);
+      });
+
+    function cmp (a, b) {
+        return a.id < b.id ? -1 : 1;
+    }
+});


### PR DESCRIPTION
The modules I'm excluding aren't there, so browserify blows up when it can't find them.
