### PR TITLE
"bundleExternal: false" cause empty file in windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -680,7 +680,7 @@ var packageFilter = function (info) {
 Browserify.prototype._resolve = function (id, parent, cb) {
     var self = this;
     
-    if (!self._bundleExternal && id[0] !== '/' && id[0] !== '.') {
+    if (self.files.indexOf(id) === -1 && !self._bundleExternal && id[0] !== '/' && id[0] !== '.') {
         return cb(null, excludeModulePath);
     }
     if (self._exclude[id]) return cb(null, excludeModulePath);


### PR DESCRIPTION
I use browserify in windows, and run the code like following.

``` javascript
var b = new browserify({
    bundleExternal: false
});

b.add('./app.js');
b.bundle().pipe(fs.createWriteStream('dist/app.js'));
```

But browserfiy create an empty content js file.

After a long time debuging, I found the following code in 'Browserify.prototype._resolve'

``` javascript
    if (!self._bundleExternal && id[0] !== '/' && id[0] !== '.') {
        return cb(null, excludeModulePath);
    }
```

I think it is proposed to recorgnize the the path for external bundle when the path is like "lodash" or "jquery/ui".
But in windows, the result of resolve('./app.js') is 'd:\xxx\app.js'. The resolve method also recorgize it as an external module, and ignore it!
