### PR TITLE
Tests for problems introduced in ~resolve@1.1.5 and fixed in resolve@1.1.6

### DIFF
--- a/test/resolve_exposed.js
+++ b/test/resolve_exposed.js
@@ -4,7 +4,7 @@ var test = require('tap').test;
 
 test('resolve exposed files', function (t) {
     t.plan(2);
-    
+
     var b = browserify(__dirname + '/resolve_exposed/main.js', {
         basedir: __dirname + '/resolve_exposed'
     });
@@ -17,4 +17,72 @@ test('resolve exposed files', function (t) {
             t.equal(x, 333);
         }
     });
+});
+
+test('resolve exposed files without extension', function (t) {
+  t.plan(2);
+
+  var b = browserify(__dirname + '/resolve_exposed/main.js', {
+    basedir: __dirname + '/resolve_exposed'
+  });
+  b.require('./x', {expose: 'xyz'});
+  b.bundle(function (err, src) {
+    t.ifError(err);
+    var c = {console: {log: log}};
+    vm.runInNewContext(src, c);
+    function log(x) {
+      t.equal(x, 333);
+    }
+  });
+});
+
+test('resolve exposed directories', function (t) {
+  t.plan(2);
+
+  var b = browserify(__dirname + '/resolve_exposed/main.js', {
+    basedir: __dirname + '/resolve_exposed'
+  });
+  b.require('./y', {expose: 'xyz'});
+  b.bundle(function (err, src) {
+    t.ifError(err);
+    var c = {console: {log: log}};
+    vm.runInNewContext(src, c);
+    function log(x) {
+      t.equal(x, 555);
+    }
+  });
+});
+
+test('resolve exposed index from directories', function (t) {
+  t.plan(2);
+
+  var b = browserify(__dirname + '/resolve_exposed/main.js', {
+    basedir: __dirname + '/resolve_exposed'
+  });
+  b.require('./y/index', {expose: 'xyz'});
+  b.bundle(function (err, src) {
+    t.ifError(err);
+    var c = {console: {log: log}};
+    vm.runInNewContext(src, c);
+    function log(x) {
+      t.equal(x, 555);
+    }
+  });
+});
+
+test('resolve exposed index.js from directories', function (t) {
+  t.plan(2);
+
+  var b = browserify(__dirname + '/resolve_exposed/main.js', {
+    basedir: __dirname + '/resolve_exposed'
+  });
+  b.require('./y/index.js', {expose: 'xyz'});
+  b.bundle(function (err, src) {
+    t.ifError(err);
+    var c = {console: {log: log}};
+    vm.runInNewContext(src, c);
+    function log(x) {
+      t.equal(x, 555);
+    }
+  });
 });

--- a/test/resolve_exposed/y/index.js
+++ b/test/resolve_exposed/y/index.js
@@ -1,0 +1,1 @@
+module.exports = 5


### PR DESCRIPTION
~~When a module is exposed, it should still resolve the way it would normally do, i.e. with/without extension and directories should fall back to index, and index from a directory should be accepted with/without extension too.~~

~~In this PR there are the tests that will fail - I am not able to run them reliably for some reason, so with `resolve@1.1.5` they simply hang, however they will pass if you `npm install resolve@1.1.2`~~

~~I'm not sure how to make them pass - that, I believe, belongs in the `resolve` module - I'll create a relevant issue there, mostly because I've no idea how things are wired up.~~

The following tests are added, where `x` is a file and `y` is a folder with an `index.js` inside:
- `b.require('./x', {expose: 'xyz'});`
- `b.require('./y', {expose: 'xyz'});`
- `b.require('./y/index', {expose: 'xyz'});`
- `b.require('./y/index.js', {expose: 'xyz'});`
