### PR TITLE
Fixed #899 - browserify removes output file if it didn't exist previously

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -56,7 +56,12 @@ var bundle = b.bundle();
 bundle.on('error', errorExit);
 
 var outfile = b.argv.o || b.argv.outfile;
+var outfileExists = true;
+
 if (outfile) {
+    var tmp = fs.createReadStream(outfile);
+    tmp.on('error', function() { outfileExists = false; });
+    tmp.close();
     bundle.pipe(fs.createWriteStream(outfile));
 }
 else {
@@ -77,6 +82,9 @@ function errorExit(err) {
     }
     else {
         console.error(String(err));
+    }
+    if (!outfileExists) {
+        fs.unlinkSync(outfile);
     }
     process.exit(1);
 }

--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -56,12 +56,11 @@ var bundle = b.bundle();
 bundle.on('error', errorExit);
 
 var outfile = b.argv.o || b.argv.outfile;
-var outfileExists = true;
+var outfileExists = false;
 
 if (outfile) {
-    var tmp = fs.createReadStream(outfile);
-    tmp.on('error', function() { outfileExists = false; });
-    tmp.destroy();
+    try { outfileExists = !!fs.lstatSync(outfile); }
+    catch (e) {}
     bundle.pipe(fs.createWriteStream(outfile));
 }
 else {

--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -61,7 +61,7 @@ var outfileExists = true;
 if (outfile) {
     var tmp = fs.createReadStream(outfile);
     tmp.on('error', function() { outfileExists = false; });
-    tmp.close();
+    tmp.destroy();
     bundle.pipe(fs.createWriteStream(outfile));
 }
 else {


### PR DESCRIPTION
The change is trivial. I didn't use fs.exists() because it's being deprecated soon according to the recent Node documentation.
