### PR TITLE
Dynamically calculate __dirname and __filename when --node is passed

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+var path = require('path');
 var mdeps = require('module-deps');
 var depsSort = require('deps-sort');
 var bpack = require('browser-pack');
@@ -551,6 +552,19 @@ Browserify.prototype._createDeps = function (opts) {
                 return through();
             }
         }
+
+        if (opts.commondir === false && opts.builtins === false) {
+          opts.insertGlobalVars = xtend({
+            __dirname: function(file, basedir) {
+              var dir = path.dirname(path.relative(basedir, file));
+              return 'require("path").join(__dirname,' + dir.split(path.sep).map(JSON.stringify).join(',') + ')';
+            },
+            __filename: function(file, basedir) {
+              var filename = path.relative(basedir, file);
+              return 'require("path").join(__dirname,' + filename.split(path.sep).map(JSON.stringify).join(',') + ')';
+            }
+          }, opts.insertGlobalVars);
+        }
         
         var vars = xtend({
             process: function () { return "require('_process')" },
@@ -560,11 +574,11 @@ Browserify.prototype._createDeps = function (opts) {
             vars.process = undefined;
             vars.buffer = undefined;
         }
-        
+
         return insertGlobals(file, xtend(opts, {
             debug: opts.debug,
             always: opts.insertGlobals,
-            basedir: opts.commondir === false
+            basedir: opts.commondir === false && isArray(opts.builtins)
                 ? '/'
                 : opts.basedir || process.cwd()
             ,

--- a/test/bare/dirname-filename.js
+++ b/test/bare/dirname-filename.js
@@ -1,0 +1,4 @@
+console.log([
+  __dirname,
+  __filename
+]);

--- a/test/no_builtins.js
+++ b/test/no_builtins.js
@@ -1,12 +1,14 @@
 var browserify = require('../');
 var test = require('tap').test;
+var path = require('path');
 var vm = require('vm');
 
 test('builtins false', function (t) {
     t.plan(1);
-    
+
+    var file = __dirname + '/no_builtins/main.js';
     var b = browserify({
-        entries: [ __dirname + '/no_builtins/main.js' ],
+        entries: [ file ],
         commondir: false,
         builtins: false
     });
@@ -15,7 +17,8 @@ test('builtins false', function (t) {
             console: { log: function (msg) {
                 t.equal(msg, 'beep boop\n');
             } },
-            require: require
+            require: require,
+            __dirname: process.cwd()
         };
         vm.runInNewContext(src, c);
     });


### PR DESCRIPTION
When `--no-commondir` is set (as a consequence of `--node` for example),
it will cause the final bundle to hardcode absolute values of the
machine that generated the bundle in order to resolve `__dirname` and
`__filename`. For example, consider a `foo.js` file containing:

```js
console.log(__dirname);
console.log(__filename);
```

Calling `browserify --node` on it results in:

```js
(function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
(function (__filename,__dirname){
console.log(__dirname);
console.log(__filename);

}).call(this,"/Users/jviotti/Projects/playground/node-browserify/foo.js","/Users/jviotti/Projects/playground/node-browserify")
},{}]},{},[1]);
```

Notice the absolute paths at the end of the bundle. This means that
Browserify node users can't generate a bundle in one machine, and expect
it to run without issues on another machine.

As a solution, we can use the final bundle's `__dirname` to dynamically
resolve every file's `__dirname` and `__filename`. This change only
takes place when `--node` is set, and keeps Browserify backwards
compatible.

For example, the above output might contain the following line:

```
}).call(this,require("path").join(__dirname,"foo.js"),require("path").join(__dirname,"."))
```

Fixes: https://github.com/substack/node-browserify/issues/1723
See: https://github.com/resin-io/etcher/issues/1429
See: https://github.com/resin-io/etcher/pull/1409
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>