### PR TITLE
 Array support for b.exclude() and b.ignore()

### DIFF
--- a/index.js
+++ b/index.js
@@ -263,6 +263,13 @@ Browserify.prototype.external = function (file, opts) {
 
 Browserify.prototype.exclude = function (file, opts) {
     if (!opts) opts = {};
+    if (isArray(file)) {
+        var self = this;
+        file.forEach(function(file) {
+            self.exclude(file, opts);
+        });
+        return this;
+    }
     var basedir = defined(opts.basedir, process.cwd());
     this._exclude.push(file);
     this._exclude.push('/' + relativePath(basedir, file));
@@ -271,6 +278,13 @@ Browserify.prototype.exclude = function (file, opts) {
 
 Browserify.prototype.ignore = function (file, opts) {
     if (!opts) opts = {};
+    if (isArray(file)) {
+        var self = this;
+        file.forEach(function(file) {
+            self.ignore(file, opts);
+        });
+        return this;
+    }
     var basedir = defined(opts.basedir, process.cwd());
 
     // Handle relative paths

--- a/readme.markdown
+++ b/readme.markdown
@@ -538,11 +538,15 @@ from the current bundle as the bundle in `file` gets bundled.
 
 Prevent the module name or file at `file` from showing up in the output bundle.
 
+If `file` is an array, each item in `file` will be ignored.
+
 Instead you will get a file with `module.exports = {}`.
 
 ## b.exclude(file)
 
 Prevent the module name or file at `file` from showing up in the output bundle.
+
+If `file` is an array, each item in `file` will be excluded.
 
 If your code tries to `require()` that file it will throw unless you've provided
 another mechanism for loading it.

--- a/test/exclude.js
+++ b/test/exclude.js
@@ -1,0 +1,21 @@
+var browserify = require('../');
+var test = require('tap').test;
+var vm = require('vm');
+
+test('exclude array', function(t) {
+	t.plan(2);
+
+	var b = browserify();
+	b.add(__dirname + '/exclude/array.js');
+	b.exclude([
+		__dirname + '/exclude/skip.js',
+		__dirname + '/exclude/skip2.js'
+	]);
+
+	b.bundle(function (err, src) {
+		if (err) {
+			t.fail(err);
+		}
+		vm.runInNewContext(src, { t: t });
+	});
+});

--- a/test/exclude/array.js
+++ b/test/exclude/array.js
@@ -1,0 +1,2 @@
+t.throws(function () { require('./skip.js') });
+t.throws(function () { require('./skip2.js') });

--- a/test/exclude/skip.js
+++ b/test/exclude/skip.js
@@ -1,0 +1,1 @@
+t.fail('this file should have been skipped');

--- a/test/exclude/skip2.js
+++ b/test/exclude/skip2.js
@@ -1,0 +1,1 @@
+t.fail('this file should have been skipped');

--- a/test/ignore.js
+++ b/test/ignore.js
@@ -4,20 +4,38 @@ var vm = require('vm');
 
 test('ignore', function (t) {
     t.plan(1);
-    
+
     var b = browserify();
     b.add(__dirname + '/ignore/main.js');
     b.ignore( __dirname + '/ignore/skip.js');
-    
+
     b.bundle(function (err, src) {
         if (err) t.fail(err);
         vm.runInNewContext(src, { t: t });
     });
 });
 
+test('ignore array', function(t) {
+	t.plan(2);
+
+	var b = browserify();
+	b.add(__dirname + '/ignore/array.js');
+	b.ignore([
+		__dirname + '/ignore/skip.js',
+		__dirname + '/ignore/skip2.js'
+	]);
+
+	b.bundle(function (err, src) {
+		if (err) {
+			t.fail(err);
+		}
+		vm.runInNewContext(src, { t: t });
+	});
+});
+
 test('ignore by package or id', function (t) {
     t.plan(3);
-  
+
     var b = browserify();
     b.add(__dirname + '/ignore/by-id.js');
     b.ignore('events');

--- a/test/ignore/array.js
+++ b/test/ignore/array.js
@@ -1,0 +1,2 @@
+t.deepEqual(require('./skip.js'), {});
+t.deepEqual(require('./skip2.js'), {});

--- a/test/ignore/skip2.js
+++ b/test/ignore/skip2.js
@@ -1,0 +1,1 @@
+t.fail('this file should have been skipped');


### PR DESCRIPTION
Rebased @bakape's PR #1218 and updated it to use `isArray` instead of `isarray`, which is a thing that changed since the PR was opened 2 years ago.

Closes #1218 