### PR TITLE
apply the same behaviour to ignore function as exclude has 

### DIFF
--- a/index.js
+++ b/index.js
@@ -291,9 +291,9 @@ Browserify.prototype.ignore = function (file, opts) {
     if (file[0] === '.') {
         this._ignore.push(path.resolve(basedir, file));
     }
-    else {
-        this._ignore.push(file);
-    }
+
+    this._ignore.push(file);
+    this._ignore.push('/' + relativePath(basedir, file));
     return this;
 };
 


### PR DESCRIPTION
Honestly I haven't spent much time but I can't figure out why modules starting with `.` are resolved. Might be for external modules?  Anyway. In my case I want similar behaviour as `external()` and `exclude()` has thus my internal dependency, called `./javascript` should be ignored and replaced with empty.

## Current: 
- `exclude('./javascript')` excludes the `./javascript` folder
- `ignore('./javascript')` changes the path to relative so this module never gets ignored

## Expected: 
- `exclude('./javascript')` excludes the `./javascript` folder
- `ignore('./javascript')` ignores the `./javascript` folder (replacing it with a mock)
