### PR TITLE
[WIP] ES modules

### DIFF
--- a/bin/args.js
+++ b/bin/args.js
@@ -14,7 +14,7 @@ module.exports = function (args, opts) {
         'boolean': [
             'deps', 'pack', 'ig', 'dg', 'im', 'd', 'list', 'builtins',
             'commondir', 'bare', 'full-paths', 'bundle-external', 'bf',
-            'node'
+            'node', 'experimental-modules'
         ],
         string: [ 's', 'r', 'u', 'x', 't', 'i', 'o', 'e', 'c', 'it' ],
         alias: {
@@ -28,6 +28,7 @@ module.exports = function (args, opts) {
             s: 'standalone',
             noParse: [ 'noparse' ],
             'full-paths': [ 'fullpaths', 'fullPaths' ],
+            'experimental-modules': [ 'experimentalModules' ],
             r: 'require',
             u: 'exclude',
             x: 'external',
@@ -113,7 +114,8 @@ module.exports = function (args, opts) {
         insertGlobalVars: insertGlobalVars,
         ignoreMissing: argv['ignore-missing'] || argv.im,
         debug: argv['debug'] || argv.d,
-        standalone: argv['standalone'] || argv.s
+        standalone: argv['standalone'] || argv.s,
+        esm: argv['experimental-modules']
     }, opts));
     function error (msg) {
         var e = new Error(msg);

--- a/index.js
+++ b/index.js
@@ -651,8 +651,10 @@ Browserify.prototype._syntax = function () {
     var self = this;
     return through.obj(function (row, enc, next) {
         var h = shasum(row.source);
-        if (typeof self._syntaxCache[h] === 'undefined' && 0) {
-            var err = syntaxError(row.source, row.file || row.id);
+        if (typeof self._syntaxCache[h] === 'undefined') {
+            var err = syntaxError(row.source, row.file || row.id, {
+                sourceType: row.esm ? 'module' : 'script'
+            });
             if (err) return this.emit('error', err);
             self._syntaxCache[h] = true;
         }

--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 var mdeps = require('module-deps');
 var depsSort = require('deps-sort');
 var bpack = require('browser-pack');
-var esm = require('browserify-esm');
 var insertGlobals = require('insert-module-globals');
 var syntaxError = require('syntax-error');
 
@@ -406,7 +405,6 @@ Browserify.prototype._createPipeline = function (opts) {
     var pipeline = splicer.obj([
         'record', [ this._recorder() ],
         'deps', [ this._mdeps ],
-        'esm', [ this._esm() ],
         'json', [ this._json() ],
         'unbom', [ this._unbom() ],
         'unshebang', [ this._unshebang() ],
@@ -618,10 +616,6 @@ Browserify.prototype._recorder = function (opts) {
         if (self._ticked) this.push(null);
     }
 };
-
-Browserify.prototype._esm = function () {
-    return esm();
-}
 
 Browserify.prototype._json = function () {
     return through.obj(function (row, enc, next) {

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 var mdeps = require('module-deps');
 var depsSort = require('deps-sort');
 var bpack = require('browser-pack');
+var esm = require('browserify-esm');
 var insertGlobals = require('insert-module-globals');
 var syntaxError = require('syntax-error');
 
@@ -405,6 +406,7 @@ Browserify.prototype._createPipeline = function (opts) {
     var pipeline = splicer.obj([
         'record', [ this._recorder() ],
         'deps', [ this._mdeps ],
+        'esm', [ this._esm() ],
         'json', [ this._json() ],
         'unbom', [ this._unbom() ],
         'unshebang', [ this._unshebang() ],
@@ -617,6 +619,10 @@ Browserify.prototype._recorder = function (opts) {
     }
 };
 
+Browserify.prototype._esm = function () {
+    return esm();
+}
+
 Browserify.prototype._json = function () {
     return through.obj(function (row, enc, next) {
         if (/\.json$/.test(row.file)) {
@@ -651,7 +657,7 @@ Browserify.prototype._syntax = function () {
     var self = this;
     return through.obj(function (row, enc, next) {
         var h = shasum(row.source);
-        if (typeof self._syntaxCache[h] === 'undefined') {
+        if (typeof self._syntaxCache[h] === 'undefined' && 0) {
             var err = syntaxError(row.source, row.file || row.id);
             if (err) return this.emit('error', err);
             self._syntaxCache[h] = true;

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "assert": "^1.4.0",
     "browser-pack": "^6.0.1",
     "browser-resolve": "^1.11.0",
-    "browserify-esm": "*",
     "browserify-zlib": "~0.2.0",
     "buffer": "^5.0.2",
     "cached-path-relative": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "JSONStream": "^1.0.3",
     "assert": "^1.4.0",
-    "browser-pack": "^6.0.1",
+    "browser-pack": "browserify/browser-pack#esm",
     "browser-resolve": "^1.11.0",
     "browserify-zlib": "~0.2.0",
     "buffer": "^5.0.2",
@@ -43,7 +43,7 @@
     "inherits": "~2.0.1",
     "insert-module-globals": "^7.0.0",
     "labeled-stream-splicer": "^2.0.0",
-    "module-deps": "^4.0.8",
+    "module-deps": "browserify/module-deps#esm",
     "os-browserify": "~0.3.0",
     "parents": "^1.0.1",
     "path-browserify": "~0.0.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "assert": "^1.4.0",
     "browser-pack": "^6.0.1",
     "browser-resolve": "^1.11.0",
+    "browserify-esm": "*",
     "browserify-zlib": "~0.2.0",
     "buffer": "^5.0.2",
     "cached-path-relative": "^1.0.0",


### PR DESCRIPTION
Adds a Node-style `--experimental-modules` flag that tells module-deps (https://github.com/browserify/module-deps/pull/137) to treat `.mjs` files as ES modules. https://github.com/browserify/browser-pack/pull/81 adds a source code transform to browser-pack that wires up ES modules correctly (live bindings etc).