### PR TITLE
Set the node version in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
     "type": "git",
     "url": "http://github.com/browserify/browserify.git"
   },
+  "engines": {
+    "node": ">= 4.0"
+  },
   "keywords": [
     "browser",
     "require",


### PR DESCRIPTION
Testing against 0.10 and 0.12 was dropped in e8dbe6c8a7ffd88863ec8db3d6bfa51976be8c38