### PR TITLE
Restore support down to node 0.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,17 @@ node_js:
   - "8"
   - "6"
   - "4"
+  - "iojs"
+  - "0.12"
+  - "0.10"
+  - "0.8"
+  - "0.6"
+before_install:
+  - 'nvm install-latest-npm'
+install:
+  - 'if [ "${TRAVIS_NODE_VERSION}" = "0.6" ] || [ "${TRAVIS_NODE_VERSION}" = "0.9" ]; then nvm install --latest-npm 0.8 && npm install && nvm use "${TRAVIS_NODE_VERSION}"; else npm install; fi;'
+sudo: false
+matrix:
+  fast_finish: true
+  allow_failures:
+    - node_js: "0.6"

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,21 +18,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
       "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c="
     },
-    "acorn5-object-spread": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/acorn5-object-spread/-/acorn5-object-spread-5.0.0.tgz",
-      "integrity": "sha1-kidVtOnf2lgeJmTxd9ySGATSwdQ=",
-      "requires": {
-        "acorn": "5.3.0"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.3.0.tgz",
-          "integrity": "sha512-Yej+zOJ1Dm/IMZzzj78OntP/r3zHEaKcyNoU2lAaxPtrseM6rF0xwqoz5Q5ysAiED9hTjI2hgtvLXitlCN1/Ug=="
-        }
-      }
-    },
     "amdefine": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
@@ -713,23 +698,6 @@
         "minimalistic-assert": "1.0.0"
       }
     },
-    "detective": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/detective/-/detective-5.0.1.tgz",
-      "integrity": "sha512-dP38zI4CR5OQDahCcBIrskhscv+5x+7+fHipBdOK9gpXc8LKrSAv4fz7IQVpcwdLDU38aA2E9qsGLRZ4L5GTpg==",
-      "requires": {
-        "acorn": "5.3.0",
-        "acorn5-object-spread": "5.0.0",
-        "defined": "1.0.0"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.3.0.tgz",
-          "integrity": "sha512-Yej+zOJ1Dm/IMZzzj78OntP/r3zHEaKcyNoU2lAaxPtrseM6rF0xwqoz5Q5ysAiED9hTjI2hgtvLXitlCN1/Ug=="
-        }
-      }
-    },
     "diff": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
@@ -1319,16 +1287,16 @@
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
     },
     "module-deps": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-5.0.0.tgz",
-      "integrity": "sha512-zY4rkAha0iU068imX1eim6wqQhEZ94jvGlgwQ8pGoCX5ZVuBUJ5O2QegZlxp7ADNXW67ja4LCuVLJfPRdoEjhw==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-4.1.1.tgz",
+      "integrity": "sha1-IyFYM/HaE/1gbMuAh7RIUty4If0=",
       "requires": {
         "JSONStream": "1.3.2",
         "browser-resolve": "1.11.2",
         "cached-path-relative": "1.0.1",
-        "concat-stream": "1.6.0",
+        "concat-stream": "1.5.2",
         "defined": "1.0.0",
-        "detective": "5.0.1",
+        "detective": "4.7.1",
         "duplexer2": "0.1.4",
         "inherits": "2.0.3",
         "parents": "1.0.1",
@@ -1340,14 +1308,18 @@
         "xtend": "4.0.1"
       },
       "dependencies": {
-        "concat-stream": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
-          "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
+        "acorn": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.3.0.tgz",
+          "integrity": "sha512-Yej+zOJ1Dm/IMZzzj78OntP/r3zHEaKcyNoU2lAaxPtrseM6rF0xwqoz5Q5ysAiED9hTjI2hgtvLXitlCN1/Ug=="
+        },
+        "detective": {
+          "version": "4.7.1",
+          "resolved": "https://registry.npmjs.org/detective/-/detective-4.7.1.tgz",
+          "integrity": "sha512-H6PmeeUcZloWtdt4DAkFyzFL94arpHr3NOwwmVILFiy+9Qd4JTxxXrzfyGk/lmct2qVGBwTSwSXagqu2BxmWig==",
           "requires": {
-            "inherits": "2.0.3",
-            "readable-stream": "2.3.3",
-            "typedarray": "0.0.6"
+            "acorn": "5.3.0",
+            "defined": "1.0.0"
           }
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -918,6 +918,12 @@
         "ansi-regex": "2.1.1"
       }
     },
+    "has-template-literals": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-template-literals/-/has-template-literals-1.0.0.tgz",
+      "integrity": "sha512-OjOC7MbUgpKFF2eOwD370uzNueJ4Yk3d0fstlTTwY7YsWPM5Awb2DOXQW3LXanULW/Sf/YAcKN5mDBhTIWI95Q==",
+      "dev": true
+    },
     "hash-base": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz",
@@ -1218,6 +1224,12 @@
         "pseudomap": "1.0.2",
         "yallist": "2.1.2"
       }
+    },
+    "make-generator-function": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/make-generator-function/-/make-generator-function-1.1.0.tgz",
+      "integrity": "sha1-ho6TVRp/rx5rsab8EfcvyjIuJqg=",
+      "dev": true
     },
     "md5.js": {
       "version": "1.3.4",

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "coffee-script": "~1.10.0",
     "coffeeify": "~1.1.0",
     "isstream": "^0.1.2",
+    "make-generator-function": "^1.1.0",
     "seq": "0.3.5",
     "tap": "^10.7.2",
     "temp": "^0.8.1",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "inherits": "~2.0.1",
     "insert-module-globals": "^7.0.0",
     "labeled-stream-splicer": "^2.0.0",
-    "module-deps": "^5.0.0",
+    "module-deps": "^5.0.1",
     "os-browserify": "~0.3.0",
     "parents": "^1.0.1",
     "path-browserify": "~0.0.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "url": "http://github.com/browserify/browserify.git"
   },
   "engines": {
-    "node": ">= 4.0"
+    "node": ">= 0.8"
   },
   "keywords": [
     "browser",

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "browser-unpack": "^1.1.1",
     "coffee-script": "~1.10.0",
     "coffeeify": "~1.1.0",
+    "has-template-literals": "^1.0.0",
     "isstream": "^0.1.2",
     "make-generator-function": "^1.1.0",
     "seq": "0.3.5",

--- a/test/quotes.js
+++ b/test/quotes.js
@@ -2,10 +2,28 @@ var browserify = require('../');
 var vm = require('vm');
 var test = require('tap').test;
 
+var hasTemplateLiterals = require('has-template-literals')();
+
 test('quotes', function (t) {
-    t.plan(3);
+    t.plan(2);
 
     var b = browserify(__dirname + '/quotes/main.js');
+    b.bundle(function (err, src) {
+        var c = {
+            done : function (single, double) {
+                t.equal(single, 'success', 'single quotes');
+                t.equal(double, 'success', 'double quotes');
+                t.end();
+            }
+        };
+        vm.runInNewContext(src, c);
+    });
+});
+
+test('interpolation literals', { skip: !hasTemplateLiterals }, function (t) {
+    t.plan(3);
+
+    var b = browserify(__dirname + '/quotes/backtick.js');
     b.bundle(function (err, src) {
         var c = {
             done : function (single, double, backtick) {

--- a/test/quotes/backtick.js
+++ b/test/quotes/backtick.js
@@ -1,0 +1,1 @@
+done(require('./one.js'), require("./two.js"), require(`./three.js`));

--- a/test/quotes/main.js
+++ b/test/quotes/main.js
@@ -1,1 +1,1 @@
-done(require('./one.js'), require("./two.js"), require(`./three.js`));
+done(require('./one.js'), require("./two.js"));

--- a/test/yield.js
+++ b/test/yield.js
@@ -1,17 +1,18 @@
 var browserify = require('../');
 var test = require('tap').test;
 var vm = require('vm');
+var generatorFunction = require('make-generator-function');
 
-test('yield', function (t) {
+test('yield', { skip: !generatorFunction }, function (t) {
     t.plan(6);
     var b = browserify(__dirname + '/yield/main.js');
-    
+
     b.bundle(function (err, src) {
         t.error(err);
         var c = { console: { log: log } };
         var index = 0;
         vm.runInNewContext(src, c);
-        
+
         function log (msg) {
             t.equal(index++, msg);
         }


### PR DESCRIPTION
I downgraded module-deps to v4 and no tests broke, so the v5 upgrade seems entirely unnecessary (#1743, #1785). It's also possible that the fix for #1782 simply failed to include a regression test; however, with module-deps v4, the backticks test passes just fine.

If that's incorrect, please help by adding test cases that necessitate the upgrade, and I'll work on restoring older node support to module-deps and its [dep tree](https://github.com/browserify/detective/pull/75) first (I'll do that next, regardless).

I also enabled branch protection on `master`, so we won't be able to merge anything in the future that fails tests, unrelated to this PR.
  