### PR TITLE
 Move `bare` and `node` options into API. 

### DIFF
--- a/bin/args.js
+++ b/bin/args.js
@@ -64,19 +64,7 @@ module.exports = function (args, opts) {
         }
         return entry;
     });
-    
-    if (argv.node) {
-        argv.bare = true;
-        argv.browserField = false;
-    }
-    if (argv.bare) {
-        argv.builtins = false;
-        argv.commondir = false;
-        if (argv.igv === undefined) {
-            argv.igv = '__filename,__dirname';
-        }
-    }
-    
+
     if (argv.igv) {
         var insertGlobalVars = {};
         var wantedGlobalVars = argv.igv.split(',');
@@ -89,6 +77,8 @@ module.exports = function (args, opts) {
     
     var ignoreTransform = argv['ignore-transform'] || argv.it;
     var b = browserify(xtend({
+        node: argv.node,
+        bare: argv.bare,
         noParse: Array.isArray(argv.noParse) ? argv.noParse : [argv.noParse],
         extensions: [].concat(argv.extension).filter(Boolean).map(function (extension) {
             if (extension.charAt(0) != '.') { 

--- a/index.js
+++ b/index.js
@@ -44,6 +44,23 @@ function Browserify (files, opts) {
         opts = xtend(opts, { entries: [].concat(opts.entries || [], files) });
     }
     else opts = xtend(files, opts);
+
+    if (opts.node) {
+        opts.bare = true;
+        opts.browserField = false;
+    }
+    if (opts.bare) {
+        opts.builtins = false;
+        opts.commondir = false;
+        if (opts.insertGlobalVars === undefined) {
+            opts.insertGlobalVars = {}
+            Object.keys(insertGlobals.vars).forEach(function (name) {
+                if (name !== '__dirname' && name !== '__filename') {
+                    opts.insertGlobalVars[name] = undefined;
+                }
+            })
+        }
+    }
     
     self._options = opts;
     if (opts.noparse) opts.noParse = opts.noparse;

--- a/readme.markdown
+++ b/readme.markdown
@@ -487,6 +487,12 @@ as the `opts.vars` parameter.
 `opts.externalRequireName` defaults to `'require'` in `expose` mode but you can
 use another name.
 
+`opts.bare` creates a bundle that does not include Node builtins, and does not
+replace global Node variables except for `__dirname` and `__filename`.
+
+`opts.node` creates a bundle that runs in Node and does not use the browser
+versions of dependencies. Same as passing `{ bare: true, browserField: false }`.
+
 Note that if files do not contain javascript source code then you also need to
 specify a corresponding transform for them.
 


### PR DESCRIPTION
Allows doing

```js
browserify({ node: true })
browserify({ bare: true })
```

in the same way that you can do

```bash
browserify --node
browserify --bare
```

Fixes https://github.com/browserify/browserify/issues/1472
Fixes https://github.com/browserify/browserify/issues/1540
Fixes https://github.com/browserify/browserify/issues/1557
