### PR TITLE
ignore perf_hooks

### DIFF
--- a/lib/builtins.js
+++ b/lib/builtins.js
@@ -16,6 +16,7 @@ exports.module = require.resolve('./_empty.js');
 exports.net = require.resolve('./_empty.js');
 exports.os = require.resolve('os-browserify/browser.js');
 exports.path = require.resolve('path-browserify');
+exports.perf_hooks = require.resolve('./_empty.js')
 exports.punycode = require.resolve('punycode/');
 exports.querystring = require.resolve('querystring-es3/');
 exports.readline = require.resolve('./_empty.js');


### PR DESCRIPTION
Stub out the `perf_hooks` API so it doesn't crash when used with the `--node` flag. Thanks!