### PR TITLE
Update string_decoder and vm builtin modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "shell-quote": "^1.6.1",
     "stream-browserify": "^2.0.0",
     "stream-http": "^2.0.0",
-    "string_decoder": "~1.0.0",
+    "string_decoder": "^1.1.1",
     "subarg": "^1.0.0",
     "syntax-error": "^1.1.1",
     "through2": "^2.0.0",
@@ -69,7 +69,7 @@
     "tty-browserify": "0.0.1",
     "url": "~0.11.0",
     "util": "~0.10.1",
-    "vm-browserify": "~0.0.1",
+    "vm-browserify": "^1.0.0",
     "xtend": "^4.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
string_decoder@1.1.0 updates to the Node 9+ API.
vm-browserify@1.0.0 updates some dependency versions.

Neither of these are breaking changes, I did a major bump for vm-browserify so we can use semver properly for it in the future.