### PR TITLE
Failing test for #1746

### DIFF
--- a/test/browser_field_basedir.js
+++ b/test/browser_field_basedir.js
@@ -1,0 +1,16 @@
+var test = require('tap').test;
+var vm = require('vm');
+var browserify = require('../');
+
+test('browser field in basedir', function (t) {
+    t.plan(2);
+    var b = browserify(__dirname + '/browser_field_basedir/main', {
+        basedir: __dirname + '/browser_field_basedir'
+    });
+    b.bundle(function (err, src) {
+        if (err) { console.error(err); return t.fail() }
+        t.ifError(err);
+        vm.runInNewContext(src, { console: { log: log } });
+        function log (msg) { t.equal(msg, 'ok') }
+    });
+});

--- a/test/browser_field_basedir/main.js
+++ b/test/browser_field_basedir/main.js
@@ -1,0 +1,1 @@
+console.log('ok')

--- a/test/browser_field_basedir/package.json
+++ b/test/browser_field_basedir/package.json
@@ -1,0 +1,4 @@
+{
+    "browser": "bundle.js",
+    "main": "main.js"
+}


### PR DESCRIPTION
Not sure yet what causes this. The `basedir` option has to be set to the directory containing the package.json (or a child directory maybe, should also add a test for that).

It's trying to resolve the `bundle.js` file specified in the `browser` field, even though I tell it to use the full path to `main.js`. I might expect it to only use the `browser` field instead of the `main` field if I use the _directory_ as the entry point rather than the full file path.