### PR TITLE
Update path-browserify to v1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "module-deps": "^6.0.0",
     "os-browserify": "~0.3.0",
     "parents": "^1.0.1",
-    "path-browserify": "~0.0.0",
+    "path-browserify": "^1.0.0",
     "process": "~0.11.0",
     "punycode": "^1.3.2",
     "querystring-es3": "~0.2.0",


### PR DESCRIPTION
This version updates to the Node v10.3.0 API. **This change is breaking**,
because path methods now throw errors when called with arguments that are not
strings.

* Add `path.parse` and `path.format`.
* Add `path.posix` as an alias to `path`.
* Port tests from Node.js.

One for v17, maybe. `path.XYZ(undefined)` throwing an error is definitely going
to break existing projects. I guess they could just stay on older browserify
versions tho.

Closes #1846