### PR TITLE
Upgrade events to v3.0.0.

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "deps-sort": "^2.0.0",
     "domain-browser": "^1.2.0",
     "duplexer2": "~0.1.2",
-    "events": "^2.0.0",
+    "events": "^3.0.0",
     "glob": "^7.1.0",
     "has": "^1.0.0",
     "htmlescape": "^1.1.0",

--- a/test/util.js
+++ b/test/util.js
@@ -46,7 +46,7 @@ test('util.inherits without Object.create', function (t) {
     b.require('events');
     
     b.bundle(function (err, src) {
-        var c = { Object : { prototype: Object.prototype } };
+        var c = { Object : { prototype: Object.prototype, defineProperty: Object.defineProperty } };
         vm.runInNewContext(src, c);
         var EE = c.require('events').EventEmitter;
         


### PR DESCRIPTION
**This version drops support for IE8.** `events` no longer includes polyfills
for ES5 features. If you need to support older environments, use an ES5 shim
like [es5-shim](https://npmjs.com/package/es5-shim). Both the shim and sham
versions of es5-shim are necessary.

  - Update to events code from Node.js 10.x
    - (semver major) Adds `off()` method
  - Port more tests from Node.js

Another for v17!