### PR TITLE
Upgrade util to v0.12.0.

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "timers-browserify": "^1.0.1",
     "tty-browserify": "0.0.1",
     "url": "~0.11.0",
-    "util": "~0.10.1",
+    "util": "~0.12.0",
     "vm-browserify": "^1.0.0",
     "xtend": "^4.0.0"
   },

--- a/test/util.js
+++ b/test/util.js
@@ -1,6 +1,7 @@
 var browserify = require('../');
 var test = require('tap').test;
 var util = require('util');
+var xtend = require('xtend');
 var vm = require('vm');
 
 test('util.inspect', function (t) {
@@ -46,7 +47,8 @@ test('util.inherits without Object.create', function (t) {
     b.require('events');
     
     b.bundle(function (err, src) {
-        var c = { Object : { prototype: Object.prototype, defineProperty: Object.defineProperty } };
+        var c = xtend({}, Object);
+        delete c.create;
         vm.runInNewContext(src, c);
         var EE = c.require('events').EventEmitter;
         


### PR DESCRIPTION
This release includes `util.promisify` and `util.callbackify` support. Users have to provide their own Promise polyfill if they use those functions while their target environment doesn't support it.
No breaking changes.