### PR TITLE
Use the latest punycode(1.3.2) 

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "parents": "^1.0.1",
     "path-browserify": "~0.0.0",
     "process": "~0.11.0",
-    "punycode": "^1.3.2",
+    "punycode": "^2.1.1",
     "querystring-es3": "~0.2.0",
     "read-only-stream": "^2.0.0",
     "readable-stream": "^2.0.2",


### PR DESCRIPTION
Use the latest punycode, since punycode(1.3.2) export with:
`define('punycode', function() {
    return punycode;
});
`
which isn't portable when using requireJS.