### PR TITLE
Changing package.json to use concat-stream "^2.0.0" and tap "^12.5.3"…

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "browserify-zlib": "~0.2.0",
     "buffer": "^5.0.2",
     "cached-path-relative": "^1.0.0",
-    "concat-stream": "^1.6.0",
+    "concat-stream": "^2.0.0",
     "console-browserify": "^1.1.0",
     "constants-browserify": "~1.0.0",
     "crypto-browserify": "^3.0.0",
@@ -83,7 +83,7 @@
     "make-generator-function": "^1.1.0",
     "semver": "^5.5.0",
     "seq": "0.3.5",
-    "tap": "^10.7.2",
+    "tap": "^12.5.3",
     "temp": "^0.8.1",
     "through": "^2.3.4"
   },

--- a/test/bare.js
+++ b/test/bare.js
@@ -28,7 +28,7 @@ test('bare', function (t) {
             }
         });
         vm.runInNewContext(body, {
-            Buffer: Buffer,
+            Buffer: function (s) { return Buffer.from(s) },
             console: {
                 log: function (msg) {
                     t.ok(Buffer.isBuffer(msg));
@@ -57,7 +57,7 @@ test('bare api', function (t) {
             }
         });
         vm.runInNewContext(body, {
-            Buffer: Buffer,
+            Buffer: function (s) { return Buffer.from(s) }, 
             console: {
                 log: function (msg) {
                     t.ok(Buffer.isBuffer(msg));

--- a/test/bare_shebang.js
+++ b/test/bare_shebang.js
@@ -20,7 +20,7 @@ test('bare shebang', function (t) {
             }
         });
         vm.runInNewContext(body, {
-            Buffer: Buffer,
+            Buffer: function (s) { return Buffer.from(s) },
             console: {
                 log: function (msg) {
                     t.ok(Buffer.isBuffer(msg));

--- a/test/buffer.js
+++ b/test/buffer.js
@@ -13,8 +13,8 @@ test('utf8 buffer to base64', function (t) {
         var c = context();
         vm.runInNewContext(src, c);
         t.equal(
-            new c.require('buffer').Buffer("Ձאab", "utf8").toString("base64"),
-            new Buffer("Ձאab", "utf8").toString("base64")
+            new c.require('buffer').Buffer.from("Ձאab", "utf8").toString("base64"),
+            new Buffer.from("Ձאab", "utf8").toString("base64")
         );
     });
 });
@@ -27,8 +27,8 @@ test('utf8 buffer to hex', function (t) {
         var c = context();
         vm.runInNewContext(src, c);
         t.equal(
-            new c.require('buffer').Buffer("Ձאab", "utf8").toString("hex"),
-            new Buffer("Ձאab", "utf8").toString("hex")
+            new c.require('buffer').Buffer.from("Ձאab", "utf8").toString("hex"),
+            new Buffer.from("Ձאab", "utf8").toString("hex")
         );
     });
 });
@@ -42,8 +42,8 @@ test('ascii buffer to base64', function (t) {
         var c = context();
         vm.runInNewContext(src, c);
         t.equal(
-            new c.require('buffer').Buffer("123456!@#$%^", "ascii").toString("base64"),
-            new Buffer("123456!@#$%^", "ascii").toString("base64")
+            new c.require('buffer').Buffer.from("123456!@#$%^", "ascii").toString("base64"),
+            new Buffer.from("123456!@#$%^", "ascii").toString("base64")
         );
     });
 });
@@ -56,8 +56,8 @@ test('ascii buffer to hex', function (t) {
         var c = context();
         vm.runInNewContext(src, c);
         t.equal(
-            new c.require('buffer').Buffer("123456!@#$%^", "ascii").toString("hex"),
-            new Buffer("123456!@#$%^", "ascii").toString("hex")
+            new c.require('buffer').Buffer.from("123456!@#$%^", "ascii").toString("hex"),
+            new Buffer.from("123456!@#$%^", "ascii").toString("hex")
         );
     });
 });
@@ -70,8 +70,8 @@ test('base64 buffer to utf8', function (t) {
         var c = context();
         vm.runInNewContext(src, c);
         t.equal(
-            new c.require('buffer').Buffer("1YHXkGFi", "base64").toString("utf8"),
-            new Buffer("1YHXkGFi", "base64").toString("utf8")
+            new c.require('buffer').Buffer.from("1YHXkGFi", "base64").toString("utf8"),
+            new Buffer.from("1YHXkGFi", "base64").toString("utf8")
         );
     });
 });
@@ -85,8 +85,8 @@ test('hex buffer to utf8', function (t) {
         vm.runInNewContext(src, c);
         var B = c.require('buffer');
         t.equal(
-            new B.Buffer("d581d7906162", "hex").toString("utf8"),
-            new Buffer("d581d7906162", "hex").toString("utf8")
+            new B.Buffer.from("d581d7906162", "hex").toString("utf8"),
+            new Buffer.from("d581d7906162", "hex").toString("utf8")
         );
     });
 });
@@ -99,8 +99,8 @@ test('base64 buffer to ascii', function (t) {
         var c = context();
         vm.runInNewContext(src, c);
         t.equal(
-            new c.require('buffer').Buffer("MTIzNDU2IUAjJCVe", "base64").toString("ascii"),
-            new Buffer("MTIzNDU2IUAjJCVe", "base64").toString("ascii")
+            new c.require('buffer').Buffer.from("MTIzNDU2IUAjJCVe", "base64").toString("ascii"),
+            new Buffer.from("MTIzNDU2IUAjJCVe", "base64").toString("ascii")
         );
     });
 });
@@ -113,8 +113,8 @@ test('hex buffer to ascii', function (t) {
         var c = context();
         vm.runInNewContext(src, c);
         t.equal(
-            new c.require('buffer').Buffer("31323334353621402324255e", "hex").toString("ascii"),
-            new Buffer("31323334353621402324255e", "hex").toString("ascii")
+            new c.require('buffer').Buffer.from("31323334353621402324255e", "hex").toString("ascii"),
+            new Buffer.from("31323334353621402324255e", "hex").toString("ascii")
         );
     });
 });
@@ -126,7 +126,7 @@ test('indexing a buffer', function (t) {
     b.bundle(function (err, src) {
         var c = context();
         vm.runInNewContext(src, c);
-        var buf = c.require('buffer').Buffer('abc');
+        var buf = c.require('buffer').Buffer.from('abc');
         t.equal(buf[0], 97);
         t.equal(buf[1], 98);
         t.equal(buf[2], 99);


### PR DESCRIPTION
… to remove npm audit security warngings; updating tests to use Buffer.from() where appropriate to remove deprecation warnings in tests