### PR TITLE
Add http2 to builtins

### DIFF
--- a/lib/builtins.js
+++ b/lib/builtins.js
@@ -12,6 +12,7 @@ exports.events = require.resolve('events/');
 exports.fs = require.resolve('./_empty.js');
 exports.http = require.resolve('stream-http');
 exports.https = require.resolve('https-browserify');
+exports.http2 = require.resolve('./_empty.js');
 exports.inspector = require.resolve('./_empty.js');
 exports.module = require.resolve('./_empty.js');
 exports.net = require.resolve('./_empty.js');


### PR DESCRIPTION
Node.js 10.10.0 added the `http2` module. This change adds just enough support for `--no-builtins` (and therefore `--node`) to recognise `http2` as a Node.js built-in module and not attempt to bundle it.