### PR TITLE
Upgrade stream-http to v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "shasum": "^1.0.0",
     "shell-quote": "^1.6.1",
     "stream-browserify": "^2.0.0",
-    "stream-http": "^2.0.0",
+    "stream-http": "^3.0.0",
     "string_decoder": "^1.1.1",
     "subarg": "^1.0.0",
     "syntax-error": "^1.1.1",


### PR DESCRIPTION
This version of stream-http drops support for IE10 and below.

This should not require a major version bump since browserify 14.0.0 already upgraded the buffer package and dropped support for IE8-10. Since stream uses buffer internally, stream is already not working in IE8-10.

This lets us get the latest and best improvements.