### PR TITLE
Polyfill Object.setPrototypeOf in tests on old Node.js versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "seq": "0.3.5",
     "setprototypeof": "^1.2.0",
     "tap": "^10.7.2",
-    "temp": "^0.8.1",
+    "temp": "0.8.3",
     "through": "^2.3.4"
   },
   "author": {

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "make-generator-function": "^1.1.0",
     "semver": "^5.5.0",
     "seq": "0.3.5",
+    "setprototypeof": "^1.2.0",
     "tap": "^10.7.2",
     "temp": "^0.8.1",
     "through": "^2.3.4"

--- a/test/buffer.js
+++ b/test/buffer.js
@@ -3,6 +3,7 @@ var test = require('tap').test;
 var vm = require('vm');
 
 if (!ArrayBuffer.isView) ArrayBuffer.isView = function () { return false; };
+if (!Object.setPrototypeOf) Object.setPrototypeOf = require('setprototypeof');
 
 test('utf8 buffer to base64', function (t) {
     t.plan(1);
@@ -139,10 +140,6 @@ function context () {
     return {
         ArrayBuffer: ArrayBuffer,
         Uint8Array: Uint8Array,
-        DataView: DataView,
-        Object: {
-            defineProperty: Object.defineProperty,
-            setPrototypeOf: Object.setPrototypeOf || require('setprototypeof')
-        }
+        DataView: DataView
     };
 }

--- a/test/buffer.js
+++ b/test/buffer.js
@@ -139,6 +139,10 @@ function context () {
     return {
         ArrayBuffer: ArrayBuffer,
         Uint8Array: Uint8Array,
-        DataView: DataView
+        DataView: DataView,
+        Object: {
+            defineProperty: Object.defineProperty,
+            setPrototypeOf: Object.setPrototypeOf || require('setprototypeof')
+        }
     };
 }

--- a/test/buffer.js
+++ b/test/buffer.js
@@ -140,6 +140,7 @@ function context () {
     return {
         ArrayBuffer: ArrayBuffer,
         Uint8Array: Uint8Array,
-        DataView: DataView
+        DataView: DataView,
+        Object: Object
     };
 }

--- a/test/crypto.js
+++ b/test/crypto.js
@@ -23,6 +23,8 @@ function context (props) {
         ArrayBuffer: ArrayBuffer,
         DataView: DataView,
         Object: {
+            create: Object.create,
+            keys: Object.keys,
             defineProperty: Object.defineProperty,
             setPrototypeOf: Object.setPrototypeOf || require('setprototypeof')
         }

--- a/test/crypto.js
+++ b/test/crypto.js
@@ -13,6 +13,7 @@ var tmpdir = temp.mkdirSync({prefix: 'browserify-test'});
 fs.writeFileSync(tmpdir + '/main.js', 'beep(require("crypto"))\n');
 
 if (!ArrayBuffer.isView) ArrayBuffer.isView = function () { return false; };
+if (!Object.setPrototypeOf) Object.setPrototypeOf = require('setprototypeof');
 
 function context (props) {
     return xtend({
@@ -21,13 +22,7 @@ function context (props) {
         Uint8Array: Uint8Array,
         Int32Array: Int32Array,
         ArrayBuffer: ArrayBuffer,
-        DataView: DataView,
-        Object: {
-            create: Object.create,
-            keys: Object.keys,
-            defineProperty: Object.defineProperty,
-            setPrototypeOf: Object.setPrototypeOf || require('setprototypeof')
-        }
+        DataView: DataView
     }, props);
 }
 

--- a/test/crypto.js
+++ b/test/crypto.js
@@ -22,7 +22,8 @@ function context (props) {
         Uint8Array: Uint8Array,
         Int32Array: Int32Array,
         ArrayBuffer: ArrayBuffer,
-        DataView: DataView
+        DataView: DataView,
+        Object: Object
     }, props);
 }
 

--- a/test/crypto_ig.js
+++ b/test/crypto_ig.js
@@ -23,6 +23,8 @@ function context (props) {
         ArrayBuffer: ArrayBuffer,
         DataView: DataView,
         Object: {
+            create: Object.create,
+            keys: Object.keys,
             defineProperty: Object.defineProperty,
             setPrototypeOf: Object.setPrototypeOf || require('setprototypeof')
         }

--- a/test/crypto_ig.js
+++ b/test/crypto_ig.js
@@ -4,6 +4,7 @@ var path = require('path');
 var fs = require('fs');
 var vm = require('vm');
 var concat = require('concat-stream');
+var xtend = require('xtend');
 
 var temp = require('temp');
 temp.track();
@@ -12,6 +13,21 @@ var tmpdir = temp.mkdirSync({prefix: 'browserify-test'});
 fs.writeFileSync(tmpdir + '/main.js', 'beep(require("crypto"))\n');
 
 if (!ArrayBuffer.isView) ArrayBuffer.isView = function () { return false; };
+
+function context (props) {
+    return xtend({
+        setTimeout: setTimeout,
+        clearTimeout: clearTimeout,
+        Uint8Array: Uint8Array,
+        Int32Array: Int32Array,
+        ArrayBuffer: ArrayBuffer,
+        DataView: DataView,
+        Object: {
+            defineProperty: Object.defineProperty,
+            setPrototypeOf: Object.setPrototypeOf || require('setprototypeof')
+        }
+    }, props);
+}
 
 test('crypto --insertGlobals', function (t) {
     t.plan(2);
@@ -26,16 +42,12 @@ test('crypto --insertGlobals', function (t) {
     });
     
     ps.stdout.pipe(concat(function (src) {
-        var c = {
-            Int32Array: Int32Array,
-            ArrayBuffer: ArrayBuffer,
-            Uint8Array: Uint8Array,
-            DataView: DataView,
+        var c = context({
             beep : function (c) {
                 t.equal(typeof c.createHash, 'function');
             },
             require: function () {}
-        };
+        });
         vm.runInNewContext(src.toString('utf8'), c);
     }));
 });

--- a/test/crypto_ig.js
+++ b/test/crypto_ig.js
@@ -13,6 +13,7 @@ var tmpdir = temp.mkdirSync({prefix: 'browserify-test'});
 fs.writeFileSync(tmpdir + '/main.js', 'beep(require("crypto"))\n');
 
 if (!ArrayBuffer.isView) ArrayBuffer.isView = function () { return false; };
+if (!Object.setPrototypeOf) Object.setPrototypeOf = require('setprototypeof');
 
 function context (props) {
     return xtend({
@@ -21,13 +22,7 @@ function context (props) {
         Uint8Array: Uint8Array,
         Int32Array: Int32Array,
         ArrayBuffer: ArrayBuffer,
-        DataView: DataView,
-        Object: {
-            create: Object.create,
-            keys: Object.keys,
-            defineProperty: Object.defineProperty,
-            setPrototypeOf: Object.setPrototypeOf || require('setprototypeof')
-        }
+        DataView: DataView
     }, props);
 }
 

--- a/test/crypto_ig.js
+++ b/test/crypto_ig.js
@@ -22,7 +22,8 @@ function context (props) {
         Uint8Array: Uint8Array,
         Int32Array: Int32Array,
         ArrayBuffer: ArrayBuffer,
-        DataView: DataView
+        DataView: DataView,
+        Object: Object
     }, props);
 }
 

--- a/test/double_buffer.js
+++ b/test/double_buffer.js
@@ -3,6 +3,7 @@ var test = require('tap').test;
 var vm = require('vm');
 
 if (!ArrayBuffer.isView) ArrayBuffer.isView = function () { return false; };
+if (!Object.setPrototypeOf) Object.setPrototypeOf = require('setprototypeof');
 
 function context (t) {
     return {
@@ -10,11 +11,7 @@ function context (t) {
         setTimeout: setTimeout,
         clearTimeout: clearTimeout,
         Uint8Array: Uint8Array,
-        ArrayBuffer: ArrayBuffer,
-        Object: {
-            defineProperty: Object.defineProperty,
-            setPrototypeOf: Object.setPrototypeOf || require('setprototypeof')
-        }
+        ArrayBuffer: ArrayBuffer
     };
 }
 

--- a/test/double_buffer.js
+++ b/test/double_buffer.js
@@ -4,6 +4,20 @@ var vm = require('vm');
 
 if (!ArrayBuffer.isView) ArrayBuffer.isView = function () { return false; };
 
+function context (t) {
+    return {
+        t: t,
+        setTimeout: setTimeout,
+        clearTimeout: clearTimeout,
+        Uint8Array: Uint8Array,
+        ArrayBuffer: ArrayBuffer,
+        Object: {
+            defineProperty: Object.defineProperty,
+            setPrototypeOf: Object.setPrototypeOf || require('setprototypeof')
+        }
+    };
+}
+
 test('double buffer', function (t) {
     t.plan(1);
     
@@ -11,6 +25,6 @@ test('double buffer', function (t) {
     b.require('buffer');
     b.bundle(function (err, src) {
         if (err) return t.fail(err);
-        vm.runInNewContext(src, { t: t, Uint8Array: Uint8Array });
+        vm.runInNewContext(src, context(t));
     });
 });

--- a/test/double_buffer.js
+++ b/test/double_buffer.js
@@ -11,7 +11,8 @@ function context (t) {
         setTimeout: setTimeout,
         clearTimeout: clearTimeout,
         Uint8Array: Uint8Array,
-        ArrayBuffer: ArrayBuffer
+        ArrayBuffer: ArrayBuffer,
+        Object: Object
     };
 }
 

--- a/test/global.js
+++ b/test/global.js
@@ -3,6 +3,7 @@ var vm = require('vm');
 var test = require('tap').test;
 
 if (!ArrayBuffer.isView) ArrayBuffer.isView = function () { return false; };
+if (!Object.setPrototypeOf) Object.setPrototypeOf = require('setprototypeof');
 
 function context (t) {
     return {
@@ -10,11 +11,7 @@ function context (t) {
         setTimeout: setTimeout,
         clearTimeout: clearTimeout,
         Uint8Array: Uint8Array,
-        ArrayBuffer: ArrayBuffer,
-        Object: {
-            defineProperty: Object.defineProperty,
-            setPrototypeOf: Object.setPrototypeOf || require('setprototypeof')
-        }
+        ArrayBuffer: ArrayBuffer
     };
 }
 

--- a/test/global.js
+++ b/test/global.js
@@ -4,6 +4,20 @@ var test = require('tap').test;
 
 if (!ArrayBuffer.isView) ArrayBuffer.isView = function () { return false; };
 
+function context (t) {
+    return {
+        t: t,
+        setTimeout: setTimeout,
+        clearTimeout: clearTimeout,
+        Uint8Array: Uint8Array,
+        ArrayBuffer: ArrayBuffer,
+        Object: {
+            defineProperty: Object.defineProperty,
+            setPrototypeOf: Object.setPrototypeOf || require('setprototypeof')
+        }
+    };
+}
+
 test('global', function (t) {
     t.plan(2);
     
@@ -28,7 +42,7 @@ test('__filename and __dirname with insertGlobals: true', function (t) {
     });
     b.require(__dirname + '/global/filename.js', { expose: 'x' });
     b.bundle(function (err, src) {
-        var c = { Uint8Array: Uint8Array };
+        var c = context(t);
         c.self = c;
         vm.runInNewContext(src, c);
         var x = c.require('x');
@@ -71,7 +85,7 @@ test('process.nextTick', function (t) {
     var b = browserify();
     b.add(__dirname + '/global/tick.js');
     b.bundle(function (err, src) {
-        var c = { t: t, setTimeout: setTimeout, clearTimeout: clearTimeout };
+        var c = context(t);
         vm.runInNewContext(src, c);
     });
 });
@@ -82,11 +96,7 @@ test('Buffer', function (t) {
     var b = browserify();
     b.add(__dirname + '/global/buffer.js');
     b.bundle(function (err, src) {
-        var c = {
-            t: t,
-            Uint8Array: Uint8Array,
-            ArrayBuffer: ArrayBuffer
-        };
+        var c = context(t);
         vm.runInNewContext(src, c);
     });
 });

--- a/test/global.js
+++ b/test/global.js
@@ -11,7 +11,8 @@ function context (t) {
         setTimeout: setTimeout,
         clearTimeout: clearTimeout,
         Uint8Array: Uint8Array,
-        ArrayBuffer: ArrayBuffer
+        ArrayBuffer: ArrayBuffer,
+        Object: Object
     };
 }
 

--- a/test/leak.js
+++ b/test/leak.js
@@ -22,7 +22,8 @@ function context (t) {
         setTimeout: setTimeout,
         clearTimeout: clearTimeout,
         Uint8Array: Uint8Array,
-        ArrayBuffer: ArrayBuffer
+        ArrayBuffer: ArrayBuffer,
+        Object: Object
     };
 }
 

--- a/test/leak.js
+++ b/test/leak.js
@@ -15,6 +15,20 @@ var dirstring = dir.split(path.sep).slice(-2).join(path.sep);
 
 if (!ArrayBuffer.isView) ArrayBuffer.isView = function () { return false; };
 
+function context (t) {
+    return {
+        t: t,
+        setTimeout: setTimeout,
+        clearTimeout: clearTimeout,
+        Uint8Array: Uint8Array,
+        ArrayBuffer: ArrayBuffer,
+        Object: {
+            defineProperty: Object.defineProperty,
+            setPrototypeOf: Object.setPrototypeOf || require('setprototypeof')
+        }
+    };
+}
+
 test('leaking information about system paths (process)', function (t) {
     t.plan(4);
     
@@ -32,11 +46,7 @@ test('leaking information about system paths (process)', function (t) {
         t.equal(src.indexOf(dirstring), -1, 'temp directory visible');
         t.equal(src.indexOf(process.cwd()), -1, 'cwd directory visible');
         t.equal(src.indexOf('/home'), -1, 'home directory visible');
-        vm.runInNewContext(src, {
-            t: t,
-            setTimeout: setTimeout,
-            clearTimeout: clearTimeout
-        });
+        vm.runInNewContext(src, context(t));
     });
 });
 
@@ -54,6 +64,6 @@ test('leaking information about system paths (Buffer)', function (t) {
         t.equal(src.indexOf(dirstring), -1, 'temp directory visible');
         t.equal(src.indexOf(process.cwd()), -1, 'cwd directory visible');
         t.equal(src.indexOf('/home'), -1, 'home directory visible');
-        vm.runInNewContext(src, { t: t, setTimeout: setTimeout, Uint8Array: Uint8Array, ArrayBuffer: ArrayBuffer });
+        vm.runInNewContext(src, context(t));
     });
 });

--- a/test/leak.js
+++ b/test/leak.js
@@ -14,6 +14,7 @@ var dir = path.join(
 var dirstring = dir.split(path.sep).slice(-2).join(path.sep);
 
 if (!ArrayBuffer.isView) ArrayBuffer.isView = function () { return false; };
+if (!Object.setPrototypeOf) Object.setPrototypeOf = require('setprototypeof');
 
 function context (t) {
     return {
@@ -21,11 +22,7 @@ function context (t) {
         setTimeout: setTimeout,
         clearTimeout: clearTimeout,
         Uint8Array: Uint8Array,
-        ArrayBuffer: ArrayBuffer,
-        Object: {
-            defineProperty: Object.defineProperty,
-            setPrototypeOf: Object.setPrototypeOf || require('setprototypeof')
-        }
+        ArrayBuffer: ArrayBuffer
     };
 }
 


### PR DESCRIPTION
The `buffer` shim needs `setPrototypeOf` since https://github.com/feross/buffer/pull/238. `buffer`'s official support targets had it. Node 0.8/0.10 incidentally had the other things it needs, but not this.