### PR TITLE
gitignore - add node_modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 package-lock.json
+node_modules


### PR DESCRIPTION
the original author removed `node_modules` from the `.gitignore` a few times in the past, I think its generally considered a good idea now :+1: 