### PR TITLE
bump tap version from 10.7.2 to 14.10.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "make-generator-function": "^1.1.0",
     "semver": "^5.5.0",
     "seq": "0.3.5",
-    "tap": "^10.7.2",
+    "tap": "^14.10.6",
     "temp": "=0.8.3",
     "through": "^2.3.4"
   },


### PR DESCRIPTION
reduces number of security vulnerabilities from 169 vulnerabilities (107 low, 7 moderate, 54 high, 1 critical) to 2 low severity vulnerabilities

(all local tests passing)