### PR TITLE
I worked around not bundle sources when you set browseField false.

### DIFF
--- a/index.js
+++ b/index.js
@@ -607,10 +607,11 @@ Browserify.prototype._createDeps = function (opts) {
             }
           }, opts.insertGlobalVars);
         }
-        
-        var vars = xtend({
-            process: function () { return "require('_process')" },
-        }, opts.insertGlobalVars);
+        var vars = {};
+        if (self._options.browserField) {
+            vars.process = function () { return "require('_process')" };
+        }
+        vars = xtend(vars, opts.insertGlobalVars);
         
         if (opts.bundleExternal === false) {
             vars.process = undefined;


### PR DESCRIPTION
It was caused by injecting `require('process')` line, even if you
set browseField false

fix #1835