### PR TITLE
fix ci, skip broken tests in old node.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "htmlescape": "^1.1.0",
     "https-browserify": "^1.0.0",
     "inherits": "~2.0.1",
-    "insert-module-globals": "^7.0.0",
+    "insert-module-globals": "^7.2.1",
     "labeled-stream-splicer": "^2.0.0",
     "mkdirp-classic": "^0.5.2",
     "module-deps": "^6.2.3",

--- a/test/crypto.js
+++ b/test/crypto.js
@@ -4,6 +4,7 @@ var path = require('path');
 var fs = require('fs');
 var vm = require('vm');
 var concat = require('concat-stream');
+var semver = require('semver');
 
 var temp = require('temp');
 temp.track();
@@ -13,7 +14,8 @@ fs.writeFileSync(tmpdir + '/main.js', 'beep(require("crypto"))\n');
 
 if (!ArrayBuffer.isView) ArrayBuffer.isView = function () { return false; };
 
-test('*-browserify libs from node_modules/', function (t) {
+// `crypto-browserify` no longer works in node.js <4
+test('*-browserify libs from node_modules/', { skip: semver.lt(process.version, 'v4.0.0') }, function (t) {
     t.plan(2);
     
     var bin = __dirname + '/../bin/cmd.js';

--- a/test/crypto_ig.js
+++ b/test/crypto_ig.js
@@ -4,6 +4,7 @@ var path = require('path');
 var fs = require('fs');
 var vm = require('vm');
 var concat = require('concat-stream');
+var semver = require('semver');
 
 var temp = require('temp');
 temp.track();
@@ -13,7 +14,8 @@ fs.writeFileSync(tmpdir + '/main.js', 'beep(require("crypto"))\n');
 
 if (!ArrayBuffer.isView) ArrayBuffer.isView = function () { return false; };
 
-test('crypto --insertGlobals', function (t) {
+// `crypto-browserify` no longer works in node.js <4
+test('crypto --insertGlobals', { skip: semver.lt(process.version, 'v4.0.0') }, function (t) {
     t.plan(2);
     
     var bin = __dirname + '/../bin/cmd.js';


### PR DESCRIPTION
pulled out from https://github.com/browserify/browserify/pull/1970

a transitive dependency of crypto-browserify has started using es6 features (https://github.com/crypto-browserify/parse-asn1/issues/41).

The insert-module-globals update fixes an issue where a const declaration in bundled code could conflict with injected semiglobal variables.

We'll just have to skip the tests that run crypto modules on old node.js because of the breaking change there.