### PR TITLE
BREAKING: Update buffer to ^6.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "browser-pack": "^6.0.1",
     "browser-resolve": "^2.0.0",
     "browserify-zlib": "~0.2.0",
-    "buffer": "~5.2.1",
+    "buffer": "^6.0.3",
     "cached-path-relative": "^1.0.0",
     "concat-stream": "^1.6.0",
     "console-browserify": "^1.1.0",


### PR DESCRIPTION
Update buffer to ^6.0.3

## Browser support

BREAKING: Drop IE11, Safari 9-10 support. This affects ~1.16% of global browser users (source: https://caniuse.com/usage-table) and this number continues to decrease each month.

Since `buffer` now supports the newly added `BigInt` methods from Node.js and the implementation uses the exponentiation operator throughout, we decided to drop support for IE11 and Safari 9-10 from `buffer`.

Similar to previous `buffer` upgrades (e.g. https://github.com/browserify/browserify/pull/1678), users can manually specify an older `buffer` version if they need IE11 and Safari 9-10 support. More information about how to do this can be found in: https://github.com/browserify/browserify/issues/1980

## Semver

This should be released as semver major.