### PR TITLE
Allow passing options to `resolve`

### DIFF
--- a/index.js
+++ b/index.js
@@ -498,6 +498,10 @@ Browserify.prototype._createDeps = function (opts) {
     };
     mopts.resolve = function (id, parent, cb) {
         if (self._ignore.indexOf(id) >= 0) return cb(null, paths.empty, {});
+
+        if (opts.resolve) {
+            parent = xtend(parent, opts.resolve);
+        }
         
         self._bresolve(id, parent, function (err, file, pkg) {
             if (file && self._ignore.indexOf(file) >= 0) {

--- a/readme.markdown
+++ b/readme.markdown
@@ -486,6 +486,10 @@ $ browserify main.js --standalone Foo | derequire > bundle.js
 [insert-module-globals](https://www.npmjs.com/package/insert-module-globals)
 as the `opts.vars` parameter.
 
+`opts.resolve` will be passed to
+[resolve](https://www.npmjs.com/package/resolve)
+as the `opts` parameter.
+
 `opts.externalRequireName` defaults to `'require'` in `expose` mode but you can
 use another name.
 


### PR DESCRIPTION
This allows passing options such as `readFile/isFile/isDirectory` down to `resolve`.

I needed this while integrating browserify into a new build system that tracks dependencies for minimal rebuilds.  The existing hooks (`persistentCache` and such) only get called if a file exists (was found by `resolve`), so if resolve doesn't find a particular file, and that file is added later, there's no evidence in any of our recorded dependencies that the bundle needs to be regenerated.  Additionally, without this, it seems there's no way to cache (or load from a virtual file system) the package.json files `resolve` is loading when resolving dependencies.

Is there something already existing that I'm missing that would provide this information?