### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/bin/args.js
+++ b/bin/args.js
@@ -254,7 +254,7 @@ function splitOnColon (f) {
         if ((/[a-zA-Z]:[\\/]/.test(f)) && (pos == 1)){
             return [f]; // Windows path and colon is part of drive name
         } else {
-            return [f.substr(0, pos), f.substr(pos + 1)];
+            return [f.slice(0, pos), f.slice(pos + 1)];
         }
     }
 }


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.