### PR TITLE
Relative paths in noparse option

### DIFF
--- a/index.js
+++ b/index.js
@@ -574,6 +574,7 @@ Browserify.prototype._createDeps = function (opts) {
     }).map(function (x) {
         return path.resolve(basedir, x);
     });
+    mopts.noParse = absno;
     
     function globalTr (file) {
         if (opts.detectGlobals === false) return through();

--- a/test/noparse.js
+++ b/test/noparse.js
@@ -44,7 +44,7 @@ test('noParse array with relative paths', function (t) {
     ].map(function (x) { return path.resolve(x); }).sort();
     
     var b = browserify({
-        entries: [ __dirname + '/noparse/a.js' ],
+        entries: [__dirname + '/noparse/a.js'],
         noParse: [
             path.join('noparse/dir1/1.js'),
             path.join('noparse/node_modules/robot/main.js')

--- a/test/noparse.js
+++ b/test/noparse.js
@@ -29,3 +29,31 @@ test('noParse array', function (t) {
         t.deepEqual(actual, expected);
     });
 });
+
+test('noParse array with relative paths', function (t) {
+    process.chdir(__dirname);
+    
+    t.plan(2);
+    
+    var actual = [];
+    var expected = [
+        'noparse/a.js',
+        'noparse/b.js',
+        'noparse/dir1/1.js',
+        'noparse/node_modules/robot/main.js'
+    ].map(function (x) {return path.resolve(x);}).sort();
+    
+    var b = browserify({
+        entries: [ __dirname + '/noparse/a.js' ],
+        noParse: [
+            path.join('noparse/dir1/1.js'),
+            path.join('noparse/node_modules/robot/main.js')
+        ]
+    });
+    b.on('dep', function(dep) { actual.push(dep.file); });
+    b.bundle(function (err, src) {
+        actual.sort();
+        t.ifError(err);
+        t.deepEqual(actual, expected);
+    });
+});

--- a/test/noparse.js
+++ b/test/noparse.js
@@ -50,7 +50,7 @@ test('noParse array with relative paths', function (t) {
             path.join('noparse/node_modules/robot/main.js')
         ]
     });
-    b.on('dep', function(dep) { actual.push(dep.file); });
+    b.on('dep', function (dep) { actual.push(dep.file); });
     b.bundle(function (err, src) {
         actual.sort();
         t.ifError(err);

--- a/test/noparse.js
+++ b/test/noparse.js
@@ -41,7 +41,7 @@ test('noParse array with relative paths', function (t) {
         'noparse/b.js',
         'noparse/dir1/1.js',
         'noparse/node_modules/robot/main.js'
-    ].map(function (x) {return path.resolve(x);}).sort();
+    ].map(function (x) { return path.resolve(x); }).sort();
     
     var b = browserify({
         entries: [ __dirname + '/noparse/a.js' ],


### PR DESCRIPTION
Browserify command with relative paths via `--noparse` option doesn't work. If I pass full paths in the option everything works as expected. Digging the problem I noticed that `noparse` array are passed into `module-deps` class via constructor. And in this package there is no processing the array like in browserify package (basedir+cwd+file name in noparse array).